### PR TITLE
Fix `SOS.Target.teamnum` typo

### DIFF
--- a/packages/plugin-types/index.ts
+++ b/packages/plugin-types/index.ts
@@ -120,7 +120,7 @@ export namespace SOS {
   export interface Target {
     id: string;
     name: string;
-    team_num: TeamEnum | -1;
+    teamnum: TeamEnum | -1;
   }
 
   export interface GoalScoredData {


### PR DESCRIPTION
This type should not have an underscore.
![image](https://github.com/SilentEchoGM/sos-monorepo/assets/14057205/4042819d-ca1e-4a83-8160-756683bc17f5)


<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>